### PR TITLE
doc: use git clone recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,7 @@ RT-Thread针对ESP32的移植（使用Espressif Systems的IDF框架）
 获得RT-Thread的ESP32版本，需要安装git，并以以下方式获得代码：
 
 ```bash
-git clone https://github.com/BernardXiong/rtthread-esp-idf
-
-cd rtthread-esp-idf
-git submodule init
-git submodule update
-
-cd esp-idf-port/esp-idf
-git submodule init
-git submodule update
-
+git clone --recursive https://github.com/BernardXiong/rtthread-esp-idf
 git apply ../esp-idf-port.patch
 ```
 


### PR DESCRIPTION
It seems the port of rt-thread uses a very old version of esp-idf, so the best way to ensure the submodule sync is right after the clone procedure, this PR instruct the user to clone this repository using the recursive clone.

This forces all the underlying submodules to be synced before any other action allowing, bringing all the subprojects to their expected locations.

